### PR TITLE
Debug: Fix data type issue in JacobianBody and JacobianSpace

### DIFF
--- a/code/Python/modern_robotics.py
+++ b/code/Python/modern_robotics.py
@@ -456,7 +456,7 @@ Output:
  [-1.44321167  2.94561275  1.43306521  0.3]
  [-2.06639565  1.82881722 -1.58868628  0.4]]
     '''
-    Jb = np.array(Blist).copy()
+    Jb = np.array(Blist).copy().astype(np.float)
     T = np.eye(4)
     for i in range(len(thetalist) - 2, -1, -1):
         T = np.dot(T,MatrixExp6(VecTose3(np.array(Blist)[:, i + 1] \
@@ -485,12 +485,12 @@ Output:
  [ 0.2         0.43654132 -2.43712573  2.77535713]
  [ 0.2         2.96026613  3.23573065  2.22512443]]
     '''
-    Js = np.array(Slist).copy()
+    Js = np.array(Slist).copy().astype(np.float)
     T = np.eye(4)
     for i in range(1, len(thetalist)):
         T = np.dot(T, MatrixExp6(VecTose3(np.array(Slist)[:, i - 1] \
                                 * thetalist[i - 1])))
-        Js[:,i] = np.dot(Adjoint(T), np.array(Slist)[:, i])  
+        Js[:,i] = np.dot(Adjoint(T), np.array(Slist)[:, i]) 
     return Js
     
 '''


### PR DESCRIPTION
Hi, this is my first time actually making a serious pull request. If there is any issue with formatting and stuff, please do not hesitate to point them out. Thanks!

This request fixes a bug that I encountered which was:
If Blist or Slist has data type `int`, Jb and Js would inherit its data type, and cause
float to be automatically floored to int when assigning their columns.