### PR TITLE
Update RotInv.m for Symbolic T Matrices

### DIFF
--- a/packages/MATLAB/mr/RotInv.m
+++ b/packages/MATLAB/mr/RotInv.m
@@ -14,5 +14,5 @@ function invR = RotInv(R)
 %     0     0     1
 %     1     0     0
 
-invR = R';
+invR = transpose(R);
 end


### PR DESCRIPTION
Changing R' to transpose(R) allows you to use it on symbolic matrices by taking the non-conjugate transpose.